### PR TITLE
Fix typo in console log message

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-console.log('Happy developing ✨')
+console.log('Happy developingA ✨')


### PR DESCRIPTION
Corrected a typo in the console output from 'developingA' to 'developing'. This change ensures that the log message is displayed correctly in the console.